### PR TITLE
Remove bash command after server

### DIFF
--- a/images/alpine/lib/scripts/spigot_init.sh
+++ b/images/alpine/lib/scripts/spigot_init.sh
@@ -193,7 +193,4 @@ fi
 
 cd $SPIGOT_HOME/
 
-su -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"
-
-# fallback to root and run shell if spigot don't start/forced exit
-bash
+exec su -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"


### PR DESCRIPTION
If the server fails to start, then the container should just fail. Right now the container hangs if the minecraft server receives the stop command or fails to start.