### PR TITLE
Rebuilds jar when REV is changed, plus non-root support for Alpine

### DIFF
--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_VERSION_MAJOR=8 \
 
 # Install dependencies
 RUN apk upgrade --update && \
-    apk add --update wget curl ca-certificates openssl bash git screen util-linux && \
+    apk add --update wget curl ca-certificates openssl bash git screen util-linux sudo shadow && \
     update-ca-certificates
 
 # Install Java8
@@ -21,7 +21,10 @@ RUN apk add openjdk8-jre
 #default directory for SPIGOT-server
 ENV SPIGOT_HOME /minecraft
 
-RUN mkdir ${SPIGOT_HOME}
+RUN addgroup -g 1000 -S minecraft && \
+  adduser -u 1000 -S minecraft -G minecraft
+
+RUN echo "minecraft ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/minecraft
 
 ADD ./minecraft/ops.txt /usr/local/etc/minecraft/ops.txt
 ADD ./minecraft/white-list.txt /usr/local/etc/minecraft/white-list.txt
@@ -39,6 +42,7 @@ EXPOSE 8123
 VOLUME ["/minecraft"]
 
 ENV UID=1000
+ENV GUID=1000
 
 ENV MOTD A Minecraft Server Powered by Spigot & Docker
 ENV REV latest

--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add openjdk8-jre
 ENV SPIGOT_HOME /minecraft
 
 RUN addgroup -g 1000 -S minecraft && \
-  adduser -u 1000 -S minecraft -G minecraft
+  adduser -u 1000 -S minecraft -G minecraft -h /minecraft
 
 RUN echo "minecraft ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/minecraft
 

--- a/images/alpine/lib/scripts/spigot_init.sh
+++ b/images/alpine/lib/scripts/spigot_init.sh
@@ -32,8 +32,8 @@ fi
 # Some variables depend on other variables.
 
 # Creeper block disable is a feature of the Essentials plugin.
-if [ -n "$CREEPERBLOCKDISABLE" ]; then
-    if [ "$CREEPERBLOCKDISABLE" = "true" ]; then
+if [ -n "$ESSENTIALS_CREEPERBLOCKDMG" ]; then
+    if [ "$ESSENTIALS_CREEPERBLOCKDMG" = "true" ]; then
 	     ESSENTIALS=true
     fi
 fi

--- a/images/alpine/lib/scripts/spigot_init.sh
+++ b/images/alpine/lib/scripts/spigot_init.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 set -e
+sudo usermod --uid $UID minecraft
+sudo groupmod --gid $GUID minecraft
+
+# Change owner to minecraft.
+if [ "$SKIPCHMOD" != "true" ]; then
+  sudo chown -R minecraft:minecraft $SPIGOT_HOME/
+else
+  echo "SKIPCHMOD option enabled. If you have access issue with your files, disable it"
+fi
 
 if [ ! -e $SPIGOT_HOME/eula.txt ]; then
   if [ "$EULA" != "" ]; then
@@ -17,18 +26,40 @@ if [ ! -e $SPIGOT_HOME/eula.txt ]; then
   fi
 fi
 
-#only build if jar file does not exist
-if [ ! -f $SPIGOT_HOME/spigot.jar ]; then
+# Some variables are mandatory.
+if [ -z "$REV" ]; then
+    REV="latest"
+fi
+
+# Some variables depend on other variables.
+
+# Creeper block disable is a feature of the Essentials plugin.
+if [ -n "$CREEPERBLOCKDISABLE" ]; then
+    if [ "$CREEPERBLOCKDISABLE" = "true" ]; then
+	     ESSENTIALS=true
+    fi
+fi
+
+# Force rebuild of spigot.jar if REV is latest.
+rm -f $SPIGOT_HOME/spigot-latest.jar
+
+# Only build a new spigot.jar if a jar for this REV does not already exist.
+if [ ! -f $SPIGOT_HOME/spigot-$REV.jar ]; then
   echo "Building spigot jar file, be patient"
   mkdir -p /tmp/buildSpigot
-  cd /tmp/buildSpigot
+  pushd /tmp/buildSpigot
   wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
   HOME=/tmp/buildSpigot java -jar BuildTools.jar --rev $REV
-  cp /tmp/buildSpigot/Spigot/Spigot-Server/target/spigot-*.jar $SPIGOT_HOME/spigot.jar
+  cp /tmp/buildSpigot/Spigot/Spigot-Server/target/spigot-*.jar $SPIGOT_HOME/spigot-$REV.jar
+  popd
   rm -rf /tmp/buildSpigot
   mkdir -p $SPIGOT_HOME/plugins
 fi
 
+# Select the spigot.jar for this particular rev.
+rm -f $SPIGOT_HOME/spigot.jar && ln -s $SPIGOT_HOME/spigot-$REV.jar $SPIGOT_HOME/spigot.jar
+
+# Install WorldBorder.
 if [ -n "$WORLDBORDER" ]; then
   if [ "$WORLDBORDER" = "true" ]; then
     echo "Downloading WorldBorder..."
@@ -193,7 +224,9 @@ fi
 
 cd $SPIGOT_HOME/
 
-su -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"
+# su - minecraft -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"
+# Removing the call by minecraft because it does not have access to /proc
+/spigot_run.sh server java $JVM_OPTS -jar spigot.jar
 
 # fallback to root and run shell if spigot don't start/forced exit
 bash

--- a/images/alpine/lib/scripts/spigot_init.sh
+++ b/images/alpine/lib/scripts/spigot_init.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e
-sudo usermod --uid $UID minecraft
-sudo groupmod --gid $GUID minecraft
 
 # Change owner to minecraft.
 if [ "$SKIPCHMOD" != "true" ]; then
@@ -224,8 +222,6 @@ fi
 
 cd $SPIGOT_HOME/
 
-# su - minecraft -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"
-# Removing the call by minecraft because it does not have access to /proc
 /spigot_run.sh server java $JVM_OPTS -jar spigot.jar
 
 # fallback to root and run shell if spigot don't start/forced exit

--- a/images/ubuntu/lib/scripts/spigot_init.sh
+++ b/images/ubuntu/lib/scripts/spigot_init.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e
-sudo usermod --uid $UID minecraft
-sudo groupmod --gid $GUID minecraft
 
 # Change owner to minecraft.
 if [ "$SKIPCHMOD" != "true" ]; then
@@ -224,8 +222,6 @@ fi
 
 cd $SPIGOT_HOME/
 
-# su - minecraft -c "/spigot_run.sh server java $JVM_OPTS -jar spigot.jar"
-# Removing the call by minecraft because it does not have access to /proc
 /spigot_run.sh server java $JVM_OPTS -jar spigot.jar
 
 # fallback to root and run shell if spigot don't start/forced exit

--- a/images/ubuntu/lib/scripts/spigot_init.sh
+++ b/images/ubuntu/lib/scripts/spigot_init.sh
@@ -32,8 +32,8 @@ fi
 # Some variables depend on other variables.
 
 # Creeper block disable is a feature of the Essentials plugin.
-if [ -n "$CREEPERBLOCKDISABLE" ]; then
-    if [ "$CREEPERBLOCKDISABLE" = "true" ]; then
+if [ -n "$ESSENTIALS_CREEPERBLOCKDMG" ]; then
+    if [ "$ESSENTIALS_CREEPERBLOCKDMG" = "true" ]; then
 	     ESSENTIALS=true
     fi
 fi
@@ -68,6 +68,7 @@ if [ -n "$WORLDBORDER" ]; then
   fi
 fi
 
+# Install Dynmap.
 if [ -n "$DYNMAP" ]; then
   if [ "$DYNMAP" = "true" ]; then
     echo "Downloading Dynmap..."
@@ -90,6 +91,7 @@ if [ -n "$DYNMAP" ]; then
   fi
 fi
 
+# Install Essentials.
 if [ -n "$ESSENTIALS" ]; then
   if [ "$ESSENTIALS" = "true" ]; then
     echo "Downloading Essentials..."
@@ -114,6 +116,7 @@ if [ -n "$ESSENTIALS" ]; then
   fi
 fi
 
+# Install Clearlag.
 if [ -n "$CLEARLAG" ]; then
   if [ "$CLEARLAG" = "true" ]; then
     echo "Downloading ClearLag..."
@@ -124,6 +127,7 @@ if [ -n "$CLEARLAG" ]; then
   fi
 fi
 
+# Install PermissionsEx.
 if [ -n "$PERMISSIONSEX" ]; then
   if [ "$PERMISSIONSEX" = "true" ]; then
     echo "Downloading PermissionsEx..."


### PR DESCRIPTION
The REV variable identifies which version of Spigot to run.  If this variable
is unset, the init script sets it to "latest".  If the variable is set to
"latest", the jar file is rebuilt every time the container is started.  If
the variable is set to a version like "1.12", that particular version is built
only if it has not already been built.  This saves time on restart and makes
upgrades easy.

Part of making this work involved fixing the outstanding issue with
the Alpine image running as root.