### PR TITLE
Remove default OP

### DIFF
--- a/images/alpine/minecraft/ops.txt
+++ b/images/alpine/minecraft/ops.txt
@@ -1,1 +1,1 @@
-AshDevFr
+

--- a/images/ubuntu/minecraft/ops.txt
+++ b/images/ubuntu/minecraft/ops.txt
@@ -1,1 +1,1 @@
-AshDevFr
+


### PR DESCRIPTION
Before, the `spigot_init.sh` script would automatically add `AshDevFr` as a server operator. Additionally, there is no easy way for the user of this Docker image to remove this default operator, as it keeps getting added back each time the container is restarted. 

This represents a security risk for the server, so this pull request simply removes it so the user can manage their own operators as they see fit. 